### PR TITLE
Fixed asset bower sourcePath

### DIFF
--- a/MasonryAsset.php
+++ b/MasonryAsset.php
@@ -15,7 +15,7 @@ use yii\web\AssetBundle;
  */
 class MasonryAsset extends AssetBundle
 {
-    public $sourcePath = '@bower/masonry';
+    public $sourcePath = '@bower/jquery-masonry';
     
     public $js = [
         'jquery.masonry.min.js',


### PR DESCRIPTION
The masonry jQuery library is found in @bower/jquery-masonry, not @bower/masonry as it previously appeared in the code.